### PR TITLE
feat: Extension referring a printable version

### DIFF
--- a/resources/StructureDefinition/sdf-questionnaire-print-version.xml
+++ b/resources/StructureDefinition/sdf-questionnaire-print-version.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="sdf-questionnaire-print-version" />
+  <url value="http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-print-version" />
+  <name value="SDFPrintVersion" />
+  <status value="draft" />
+  <description value="Reference to a Binary or DocumentReference that holds a printable version for the Questionnaire" />
+  <fhirVersion value="4.0.0" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Questionnaire" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedString value="http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-print-version" />
+    </element>
+    <element id="Extension.value[x]:valueReference">
+      <path value="Extension.value[x]" />
+      <sliceName value="valueReference" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Binary" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
* An extension for a Questionnaire that references either a
  DocumentReference or Binary which contains the printable version of
  the Questionnaire