### PR TITLE
feat: Extension setting navigator state

### DIFF
--- a/resources/CodeSystem/codesystem-sdf-questionnaire-navigator-state.json
+++ b/resources/CodeSystem/codesystem-sdf-questionnaire-navigator-state.json
@@ -1,0 +1,23 @@
+{
+    "resourceType": "CodeSystem",
+    "id": "sdf-questionnaire-navigator-state",
+    "url": "http://helsenorge.no/fhir/CodeSystem/sdf-questionnaire-navigator-state",
+    "name": "SDFQuestionnaireNavigatorState",
+    "title": "SDF Questionnaire Navigator State Codes",
+    "description": "The SDF Questionnaire Navigator State Codes to put the Form Filler in different navigator states",
+    "jurisdiction": [{
+            "coding": [{
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "NO",
+                    "display": "Norway"
+                }
+            ]
+        }
+    ],
+    "concept": [{
+            "code": "navigator",
+            "display": "Navigator",
+            "definition": "A simple Table of Contents navigator style that helps you navigate within a one-page Questionnaire"
+        }
+    ]
+}

--- a/resources/StructureDefinition/sdf-questionnaire-navgiator-state.xml
+++ b/resources/StructureDefinition/sdf-questionnaire-navgiator-state.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="sdf-questionnaire-navgiator-state" />
+  <url value="http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-navgiator-state" />
+  <name value="SDFNavgiatorState" />
+  <status value="draft" />
+  <fhirVersion value="4.0.0" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Questionnaire" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedString value="http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-navgiator-state" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="http://helsenorge.no/fhir/ValueSet/sdf-questionnaire-navigator-state" />
+      </binding>
+    </element>
+    <element id="Extension.value[x].coding">
+      <path value="Extension.value[x].coding" />
+      <max value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ValueSet/valueset-sdf-questionnaire-navigator-state.json
+++ b/resources/ValueSet/valueset-sdf-questionnaire-navigator-state.json
@@ -1,0 +1,22 @@
+{
+    "resourceType": "ValueSet",
+    "id": "sdf-questionnaire-navigator-state",
+    "url": "http://helsenorge.no/fhir/ValueSet/sdf-questionnaire-navigator-state",
+    "name": "SDFQuestionnaireNavigatorState",
+    "title": "SDF Questionnaire Navigator State Codes",
+    "jurisdiction": [{
+            "coding": [{
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "NO",
+                    "display": "Norway"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [{
+                "system": "http://helsenorge.no/fhir/CodeSystem/sdf-questionnaire-navigator-state"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
* Extension setting the navigator state for the Questionnaire
* Currently only supports the 'navigator' mode which is a simple Table of
  Contents navigator