### PR TITLE
CodeSystem+ValueSet: Add CodeSystem RenderOptions

### DIFF
--- a/resources/CodeSystem/CodeSystem-RenderOptions.json
+++ b/resources/CodeSystem/CodeSystem-RenderOptions.json
@@ -1,0 +1,19 @@
+{
+    "resourceType": "CodeSystem",
+    "url": "http://helsenorge.no/fhir/CodeSystem/RenderOptions",
+    "name": "RenderOptions",
+    "concept": [
+        {
+            "code": "1",
+            "display": "Default"
+        },
+        {
+            "code": "2",
+            "display": "PDF Only"
+        },
+        {
+            "code": "3",
+            "display": "Form Filler Only"
+        }
+    ]
+}

--- a/resources/ValueSet/ValueSet-RenderOptions.json
+++ b/resources/ValueSet/ValueSet-RenderOptions.json
@@ -1,0 +1,1 @@
+{"resourceType":"ValueSet","url":"http://helsenorge.no/fhir/ValueSet/RenderOptions","name":"RenderOptions","compose":{"include":[{"system":"http://helsenorge.no/fhir/CodeSystem/RenderOptions"}]}}


### PR DESCRIPTION
This Code System includes the concepts for Render Options:
- Default: Render item in both Form Filler and PDF
- PDF Only: Render item in PDF only
- Form Filler only: Render item in Form Filler only

ValuSet: Add ValueSet references concepts from CodeSystem RenderOptions
- This ValueSet includes all concepts from CodeSystem RenderOptions.